### PR TITLE
Iterates on the new Interaction functions

### DIFF
--- a/src/client/actions/InteractionCreate.js
+++ b/src/client/actions/InteractionCreate.js
@@ -46,7 +46,7 @@ class InteractionCreateAction extends Action {
 
         const replyRequest = !sentInitial
           ? client.api.interactions(interaction.id, interaction.token).callback.post(replyData)
-          : client.api.webhooks(interaction.id, interaction.token).post(replyData);
+          : client.api.webhooks(client.user.id, interaction.token).post(replyData);
 
         sentInitial = true;
 

--- a/src/client/actions/InteractionCreate.js
+++ b/src/client/actions/InteractionCreate.js
@@ -70,7 +70,7 @@ class InteractionCreateAction extends Action {
           ? client.api.interactions(interaction.id, interaction.token).callback.post(body)
           : client.api.webhooks(client.user.id, interaction.token).post(body.data);
 
-        sentInitial = true;
+        if (!sentInitial) sentInitial = true;
 
         return replyRequest.then(response => response.id ?? '@original');
       },
@@ -88,6 +88,7 @@ class InteractionCreateAction extends Action {
       },
       async thinking(ephemeral = false) {
         if (sentInitial) return;
+        sentInitial = true;
         await client.api.interactions(interaction.id, interaction.token).callback.post({
           data: {
             type: 5,

--- a/src/client/actions/InteractionCreate.js
+++ b/src/client/actions/InteractionCreate.js
@@ -44,9 +44,9 @@ class InteractionCreateAction extends Action {
           },
         };
 
-        const replyRequest = sentInitial
+        const replyRequest = !sentInitial
           ? client.api.interactions(interaction.id, interaction.token).callback.post(replyData)
-          : client.api.interactions(interaction.id, interaction.token).post(replyData);
+          : client.api.webhooks(interaction.id, interaction.token).post(replyData);
 
         sentInitial = true;
 

--- a/src/client/actions/InteractionCreate.js
+++ b/src/client/actions/InteractionCreate.js
@@ -37,7 +37,7 @@ class InteractionCreateAction extends Action {
   async handle(data) {
     const client = this.client;
     const guild = client.guilds.cache.get(data.guild_id);
-    let sentInitial = false;
+    let sentInitialReply = false;
     const interaction = {
       id: data.id,
       token: data.token,
@@ -67,11 +67,11 @@ class InteractionCreateAction extends Action {
           },
         };
 
-        const replyRequest = !sentInitial
+        const replyRequest = !sentInitialReply
           ? client.api.interactions(interaction.id, interaction.token).callback.post(body)
           : client.api.webhooks(client.user.id, interaction.token).post(body.data);
 
-        if (!sentInitial) sentInitial = true;
+        if (!sentInitialReply) sentInitialReply = true;
 
         return replyRequest.then(response => response.id ?? '@original');
       },
@@ -88,8 +88,8 @@ class InteractionCreateAction extends Action {
         await client.api.webhooks(client.user.id, interaction.token).messages(messageId).delete();
       },
       async thinking(ephemeral = false) {
-        if (sentInitial) return;
-        sentInitial = true;
+        if (sentInitialReply) return;
+        sentInitialReply = true;
         await client.api.interactions(interaction.id, interaction.token).callback.post({
           data: {
             type: 5,

--- a/src/client/actions/InteractionCreate.js
+++ b/src/client/actions/InteractionCreate.js
@@ -19,52 +19,71 @@ class InteractionCreateAction extends Action {
       token: data.token,
       channel: client.channels.cache.get(data.channel_id),
       guild: guild,
-      member: guild ? guild.members.cache.get(data.member.user.id) || (await guild.members.fetch(data.member.user.id)) || null : null,
+      member: guild
+        ? guild.members.cache.get(data.member.user.id) || (await guild.members.fetch(data.member.user.id)) || null
+        : null,
       author: client.users.cache.get(data.member.user.id) || (await client.users.fetch(data.member.user.id)) || null,
       name: data.data.name,
-      content: data.data.options ? parseContent(data.data.options) : "",
+      content: data.data.options ? parseContent(data.data.options) : '',
       createdTimestamp: SnowflakeUtil.deconstruct(data.id).timestamp,
       options: data.data.options ? data.data.options : null,
-      reply (input) {
-        if(typeof input === 'object'){
-          client.api.interactions(interaction.id, interaction.token).callback.post({data: {
-            type: 4,
+      reply(input) {
+        if (typeof input === 'object') {
+          client.api.interactions(interaction.id, interaction.token).callback.post({
             data: {
-              embeds: [
-                input
-              ]
-         }
-       }})}else if(typeof input === 'string'){
-        client.api.interactions(interaction.id, interaction.token).callback.post({data: {
-          type: 4,
-          data: {
-            content: input
-       }}})}else {
-         throw new Error('Not embed or string')
-       }
-    },
-      edit (input) {
-        if(typeof input === 'object'){
-          client.api.webhooks(client.user.id, interaction.token).messages('@original').patch({data: {
-            embeds: [
-              input
-            ]
-        }})}else if(typeof input === 'string'){
-        client.api.webhooks(client.user.id, interaction.token).messages('@original').patch({data: {
-          content: input
-      }})}else {
-         throw new Error('Not embed or string')
-       }
-
+              type: 4,
+              data: {
+                embeds: [input],
+              },
+            },
+          });
+        } else if (typeof input === 'string') {
+          client.api.interactions(interaction.id, interaction.token).callback.post({
+            data: {
+              type: 4,
+              data: {
+                content: input,
+              },
+            },
+          });
+        } else {
+          throw new Error('Not embed or string');
+        }
       },
-      thinking (input) {
-        client.api.interactions(interaction.id, interaction.token).callback.post({data: {
-          type: 5,
+      edit(input) {
+        if (typeof input === 'object') {
+          client.api
+            .webhooks(client.user.id, interaction.token)
+            .messages('@original')
+            .patch({
+              data: {
+                embeds: [input],
+              },
+            });
+        } else if (typeof input === 'string') {
+          client.api
+            .webhooks(client.user.id, interaction.token)
+            .messages('@original')
+            .patch({
+              data: {
+                content: input,
+              },
+            });
+        } else {
+          throw new Error('Not embed or string');
+        }
+      },
+      thinking() {
+        client.api.interactions(interaction.id, interaction.token).callback.post({
           data: {
-              content: ''
-       }}})
-      }
-    }
+            type: 5,
+            data: {
+              content: '',
+            },
+          },
+        });
+      },
+    };
     client.emit(Events.INTERACTION_CREATE, interaction);
     return { interaction };
   }

--- a/src/client/actions/InteractionCreate.js
+++ b/src/client/actions/InteractionCreate.js
@@ -16,11 +16,12 @@ const buildInteractionReplyData = input => {
   if (typeof input === 'object') {
     if (Array.isArray(input)) {
       return {
+        content: '',
         embeds: input,
       };
     } else {
       return {
-        content: input.content,
+        content: input.content ?? '',
         embeds: input.embeds,
       };
     }
@@ -79,6 +80,7 @@ class InteractionCreateAction extends Action {
         if (!input) {
           throw new Error('Message content or embeds must be provided');
         }
+        console.log(replyData);
         await client.api.webhooks(client.user.id, interaction.token).messages(messageId).patch({
           data: replyData,
         });

--- a/src/client/actions/InteractionCreate.js
+++ b/src/client/actions/InteractionCreate.js
@@ -80,7 +80,6 @@ class InteractionCreateAction extends Action {
         if (!input) {
           throw new Error('Message content or embeds must be provided');
         }
-        console.log(replyData);
         await client.api.webhooks(client.user.id, interaction.token).messages(messageId).patch({
           data: replyData,
         });

--- a/src/client/actions/InteractionCreate.js
+++ b/src/client/actions/InteractionCreate.js
@@ -33,24 +33,24 @@ class InteractionCreateAction extends Action {
           throw new Error('Message text or embed must be provided');
         }
 
+        const replyData = {
+          data: {
+            type: 4,
+            data: {
+              content: message,
+              embeds: embeds ?? [],
+              flags: ephemeral ? 64 : null,
+            },
+          },
+        };
+
         const replyRequest = sentInitial
-          ? client.api.interactions(interaction.id, interaction.token).callback
-          : client.api.interactions(interaction.id, interaction.token);
+          ? client.api.interactions(interaction.id, interaction.token).callback.post(replyData)
+          : client.api.interactions(interaction.id, interaction.token).post(replyData);
 
         sentInitial = true;
 
-        replyRequest
-          .post({
-            data: {
-              type: 4,
-              data: {
-                content: message,
-                embeds: embeds ?? [],
-                flags: ephemeral ? 64 : null,
-              },
-            },
-          })
-          .then(response => console.log(response));
+        replyRequest.then(response => console.log(response));
       },
       edit(message, embeds, ephemeral = false) {
         if (!message && !embeds) {

--- a/src/client/actions/InteractionCreate.js
+++ b/src/client/actions/InteractionCreate.js
@@ -14,6 +14,7 @@ class InteractionCreateAction extends Action {
   async handle(data) {
     const client = this.client;
     const guild = client.guilds.cache.get(data.guild_id);
+    let sentInitial = false;
     const interaction = {
       id: data.id,
       token: data.token,
@@ -31,16 +32,25 @@ class InteractionCreateAction extends Action {
         if (!message && !embeds) {
           throw new Error('Message text or embed must be provided');
         }
-        client.api.interactions(interaction.id, interaction.token).callback.post({
-          data: {
-            type: 4,
+
+        const replyRequest = sentInitial
+          ? client.api.interactions(interaction.id, interaction.token).callback
+          : client.api.interactions(interaction.id, interaction.token);
+
+        sentInitial = true;
+
+        replyRequest
+          .post({
             data: {
-              content: message,
-              embeds: embeds ?? [],
-              flags: ephemeral ? 64 : null,
+              type: 4,
+              data: {
+                content: message,
+                embeds: embeds ?? [],
+                flags: ephemeral ? 64 : null,
+              },
             },
-          },
-        });
+          })
+          .then(response => console.log(response));
       },
       edit(message, embeds, ephemeral = false) {
         if (!message && !embeds) {

--- a/src/client/actions/InteractionCreate.js
+++ b/src/client/actions/InteractionCreate.js
@@ -74,21 +74,21 @@ class InteractionCreateAction extends Action {
 
         return replyRequest.then(response => response.id ?? '@original');
       },
-      edit(input, messageId = '@original') {
+      async edit(input, messageId = '@original') {
         const replyData = buildInteractionReplyData(input);
         if (!input) {
           throw new Error('Message content or embeds must be provided');
         }
-        client.api.webhooks(client.user.id, interaction.token).messages(messageId).patch({
+        await client.api.webhooks(client.user.id, interaction.token).messages(messageId).patch({
           data: replyData,
         });
       },
-      delete(messageId = '@original') {
-        client.api.webhooks(client.user.id, interaction.token).messages(messageId).delete();
+      async delete(messageId = '@original') {
+        await client.api.webhooks(client.user.id, interaction.token).messages(messageId).delete();
       },
-      thinking(ephemeral = false) {
+      async thinking(ephemeral = false) {
         if (sentInitial) return;
-        client.api.interactions(interaction.id, interaction.token).callback.post({
+        await client.api.interactions(interaction.id, interaction.token).callback.post({
           data: {
             type: 5,
             data: {

--- a/src/client/actions/InteractionCreate.js
+++ b/src/client/actions/InteractionCreate.js
@@ -46,7 +46,7 @@ class InteractionCreateAction extends Action {
 
         const replyRequest = !sentInitial
           ? client.api.interactions(interaction.id, interaction.token).callback.post(replyData)
-          : client.api.webhooks(client.user.id, interaction.token).post(replyData);
+          : client.api.webhooks(client.user.id, interaction.token).post(replyData.data);
 
         sentInitial = true;
 

--- a/src/client/actions/InteractionCreate.js
+++ b/src/client/actions/InteractionCreate.js
@@ -27,58 +27,43 @@ class InteractionCreateAction extends Action {
       content: data.data.options ? parseContent(data.data.options) : '',
       createdTimestamp: SnowflakeUtil.deconstruct(data.id).timestamp,
       options: data.data.options ? data.data.options : null,
-      reply(input) {
-        if (typeof input === 'object') {
-          client.api.interactions(interaction.id, interaction.token).callback.post({
+      reply(message, embeds, ephemeral = false) {
+        if (!message && !embeds) {
+          throw new Error('Message text or embed must be provided');
+        }
+        client.api.interactions(interaction.id, interaction.token).callback.post({
+          data: {
+            type: 4,
             data: {
-              type: 4,
-              data: {
-                embeds: [input],
-              },
+              content: message,
+              embeds: embeds ?? [],
+              flags: ephemeral ? 64 : null,
+            },
+          },
+        });
+      },
+      edit(message, embeds, ephemeral = false) {
+        if (!message && !embeds) {
+          throw new Error('Message text or embed must be provided');
+        }
+        client.api
+          .webhooks(client.user.id, interaction.token)
+          .messages('@original')
+          .patch({
+            data: {
+              content: message,
+              embeds: embeds ?? [],
+              flags: ephemeral ? 64 : null,
             },
           });
-        } else if (typeof input === 'string') {
-          client.api.interactions(interaction.id, interaction.token).callback.post({
-            data: {
-              type: 4,
-              data: {
-                content: input,
-              },
-            },
-          });
-        } else {
-          throw new Error('Not embed or string');
-        }
       },
-      edit(input) {
-        if (typeof input === 'object') {
-          client.api
-            .webhooks(client.user.id, interaction.token)
-            .messages('@original')
-            .patch({
-              data: {
-                embeds: [input],
-              },
-            });
-        } else if (typeof input === 'string') {
-          client.api
-            .webhooks(client.user.id, interaction.token)
-            .messages('@original')
-            .patch({
-              data: {
-                content: input,
-              },
-            });
-        } else {
-          throw new Error('Not embed or string');
-        }
-      },
-      thinking() {
+      thinking(ephemeral = false) {
         client.api.interactions(interaction.id, interaction.token).callback.post({
           data: {
             type: 5,
             data: {
               content: '',
+              flags: ephemeral ? 64 : null,
             },
           },
         });

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2806,6 +2806,7 @@ declare module 'discord.js' {
 
   interface Interaction {
     id: string;
+    token: string;
     channel: TextChannel;
     guild: Guild;
     member: GuildMember | null;
@@ -2814,6 +2815,9 @@ declare module 'discord.js' {
     content: string;
     createdTimestamp: number;
     options: { value: string; name: string }[] | null;
+    reply: (input: MessageEmbed | string) => void;
+    edit: (input: MessageEmbed | string) => void;
+    thinking: () => void;
   }
 
   interface MessageEmbedProvider {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2805,6 +2805,7 @@ declare module 'discord.js' {
   }
 
   interface InteractionOptions {
+    type: number;
     value: string;
     name: string;
     options?: InteractionOptions[];

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2804,6 +2804,12 @@ declare module 'discord.js' {
     footer?: Partial<MessageEmbedFooter> & { icon_url?: string; proxy_icon_url?: string };
   }
 
+  interface InteractionOptions {
+    value: string;
+    name: string;
+    options?: InteractionOptions[];
+  }
+
   interface Interaction {
     id: string;
     token: string;
@@ -2814,7 +2820,7 @@ declare module 'discord.js' {
     name: string;
     content: string;
     createdTimestamp: number;
-    options: { value: string; name: string }[] | null;
+    options?: InteractionOptions[];
     /**
      * Replies to this Interaction.
      *

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2815,9 +2815,9 @@ declare module 'discord.js' {
     content: string;
     createdTimestamp: number;
     options: { value: string; name: string }[] | null;
-    reply: (input: MessageEmbed | string) => void;
-    edit: (input: MessageEmbed | string) => void;
-    thinking: () => void;
+    reply: (message?: string, embeds?: MessageEmbed[], ephemeral?: boolean) => void;
+    edit: (message?: string, embeds?: MessageEmbed[], ephemeral?: boolean) => void;
+    thinking: (ephemeral?: boolean) => void;
   }
 
   interface MessageEmbedProvider {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2815,9 +2815,37 @@ declare module 'discord.js' {
     content: string;
     createdTimestamp: number;
     options: { value: string; name: string }[] | null;
-    reply: (message?: string, embeds?: MessageEmbed[], ephemeral?: boolean) => void;
-    edit: (message?: string, embeds?: MessageEmbed[], ephemeral?: boolean) => void;
-    thinking: (ephemeral?: boolean) => void;
+    /**
+     * Replies to this Interaction.
+     * @arg input - A message string, embed array, or object containing both
+     * @arg ephemeral - Make the reply viewable only to the command sender. If false, reply is public
+     * @returns A Promise that resolves a `messageId` which can be used with `.edit(...)` and `.delete(...)`
+     */
+    reply: (
+      input?: string | MessageEmbed[] | { content: string; embeds: MessageEmbed[] },
+      ephemeral?: boolean,
+    ) => Promise<string>;
+    /**
+     * Edit a previous reply to this Interaction
+     * @arg input - A message string, embed array, or object containing both
+     * @arg messageId - The id of the message to delete. If omitted, the original reply message is deleted.
+     */
+    edit: (
+      input?: string | MessageEmbed[] | { content: string; embeds: MessageEmbed[] },
+      messageId?: string,
+    ) => Promise<void>;
+    /**
+     * Sends a simple reply that makes the bot say "is thinking..."
+     *
+     * **Note:** You must use `.edit(...)` if you want to update the reply with an actual message later on.
+     * @arg ephemeral - Make the reply viewable only to the command sender. If false, reply is public
+     */
+    thinking: (ephemeral?: boolean) => Promise<void>;
+    /**
+     * Deletes a reply to the Interaction
+     * @arg messageId - The id of the message to delete. If omitted, the original reply message is deleted.
+     */
+    delete: (messageId?: string) => Promise<void>;
   }
 
   interface MessageEmbedProvider {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2817,6 +2817,8 @@ declare module 'discord.js' {
     options: { value: string; name: string }[] | null;
     /**
      * Replies to this Interaction.
+     *
+     * **Note:** Ephemeral messages don't appear to support embeds at this time.
      * @arg input - A message string, embed array, or object containing both
      * @arg ephemeral - Make the reply viewable only to the command sender. If false, reply is public
      * @returns A Promise that resolves a `messageId` which can be used with `.edit(...)` and `.delete(...)`
@@ -2827,6 +2829,8 @@ declare module 'discord.js' {
     ) => Promise<string>;
     /**
      * Edit a previous reply to this Interaction
+     *
+     * **Note:** Ephemeral messages don't appear to support embeds at this time.
      * @arg input - A message string, embed array, or object containing both
      * @arg messageId - The id of the message to delete. If omitted, the original reply message is deleted.
      */
@@ -2843,6 +2847,8 @@ declare module 'discord.js' {
     thinking: (ephemeral?: boolean) => Promise<void>;
     /**
      * Deletes a reply to the Interaction
+     *
+     * **Note:** You cannot delete ephemeral messages.
      * @arg messageId - The id of the message to delete. If omitted, the original reply message is deleted.
      */
     delete: (messageId?: string) => Promise<void>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
- Added a `.delete()` function for deleting replies to the Interaction
- All functions (`.thinking()`, `.reply()`, `.edit()`, `.delete()`) now return Promises so they can be awaited if desired.
- Supported types for the `input` arg
in `.reply()` and `.edit()` are now: message string, array of embeds, or an object containing both. This should give maximum flexibility.
- Added an optional `ephemeral` boolean arg to `.reply()` and `.thinking()`. ["Ephemeral" messages](https://discord.com/developers/docs/interactions/slash-commands#interaction-response-interactionapplicationcommandcallbackdata) are only visible to the command sender
- Updated `.reply()` to support sending additional [Followup Messages](https://discord.com/developers/docs/interactions/slash-commands#followup-messages).
  - To that end, `.reply()` now returns a Promise that resolves a message id which can be used for `.edit()` and `.delete()`
  
**Example:**
```ts
client.on("interactionCreate", async interaction => { 
    if (interaction.name === "ping") { 
        // send initial reply
        await interaction.reply("Pong");

        // send followup
        const messageId = await interaction.reply({
            content: "Follow up message",
            embeds: [new MessageEmbed().setDescription('Follow up test')]
        });
       
        // send another follow up but only visible to the command sender
        await interaction.reply('Ephemeral test', true);

        setTimeout(() => {
            // delete initial reply
            interaction.delete();

            // edit 1st followup
            interaction.edit('Edited follow up message', messageId);
        }, 5000);
    } 
});
```

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

